### PR TITLE
fixed input error for credit and debit forms that didn't allow for floating point values.

### DIFF
--- a/src/components/Credits.js
+++ b/src/components/Credits.js
@@ -30,7 +30,7 @@ const Credits = ({
         <label id="description"> Description: </label>
         <input type="text" name="description"/>
         <label id="amount"> Amount: </label>
-        <input type="number" name="amount"/>
+        <input type="number" name="amount" step="0.01"/>
         <button type="submit">Add Credits</button>
       </form>
       <Link to="/">Home</Link>

--- a/src/components/Debits.js
+++ b/src/components/Debits.js
@@ -29,7 +29,7 @@ const Debits = ({
       <label id="description"> Description: </label>
         <input type="text" name="description"/>
         <label id="amount"> Amount: </label>
-        <input type="number" name="amount"/>
+        <input type="number" name="amount" step="0.01"/>
         <button type="submit">Add Debit</button>
       </form>
       <Link to="/">Home</Link>


### PR DESCRIPTION
Now users are able to input credit or debit amount with two decimal places.